### PR TITLE
feat: #2 gRPC stream size limited to 16MB max message size

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ way to verify everything ran successfully. Arkeep fixes this.
 
 **Agent** runs on each machine to be backed up. It initiates a persistent outbound gRPC connection to the server — it never listens on any port. This makes deployment behind NAT and corporate firewalls effortless.
 
+**gRPC transport limits:** the server and agent both enforce a maximum message size of **16 MB** per RPC call. The agent also sends keepalive pings every 30 seconds (10-second timeout) to detect stale connections early. These values are fixed in the binary; no configuration is required.
+
 **GUI** is a Vue 3 PWA served directly by the server as embedded static files. No separate web server required.
 
 ---

--- a/agent/internal/connection/manager.go
+++ b/agent/internal/connection/manager.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -368,9 +369,20 @@ func (m *Manager) connect(ctx context.Context) error {
 		return fmt.Errorf("failed to build transport credentials: %w", err)
 	}
 
+	const maxMsgSize = 16 * 1024 * 1024 // 16 MB — matches server config
+
 	conn, err := grpc.NewClient(
 		m.cfg.ServerAddr,
 		grpc.WithTransportCredentials(transportCreds),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMsgSize),
+			grpc.MaxCallSendMsgSize(maxMsgSize),
+		),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                30 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("dial failed: %w", err)

--- a/server/internal/grpc/server.go
+++ b/server/internal/grpc/server.go
@@ -136,9 +136,13 @@ func (s *Server) ListenAndServe(ctx context.Context, listenAddr string) error {
 // pre-created net.Listener so callers (e.g. integration tests) can control
 // the bind address and retrieve the actual port before Serve is called.
 func (s *Server) Serve(ctx context.Context, lis net.Listener) error {
+	const maxMsgSize = 16 * 1024 * 1024 // 16 MB — matches agent client config
+
 	opts := []grpc.ServerOption{
 		grpc.UnaryInterceptor(s.authUnaryInterceptor),
 		grpc.StreamInterceptor(s.authStreamInterceptor),
+		grpc.MaxRecvMsgSize(maxMsgSize),
+		grpc.MaxSendMsgSize(maxMsgSize),
 	}
 
 	switch {


### PR DESCRIPTION
<!-- Describe what this PR changes and why. One paragraph is enough. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues

Closes #2
