### PR TITLE
fix: parse hook command as plain string and account for timeout + gui didn't show saved hooks

### DIFF
--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -97,6 +97,13 @@ type retentionPayload struct {
 	Yearly  int `json:"yearly"`
 }
 
+type hookPayload struct {
+	Name        string   `json:"name"`
+	Command     string   `json:"command"`
+	Args    		[]string `json:"args"`
+	TimeoutSecs int      `json:"timeout_secs"`
+}
+
 // queueSize is the maximum number of jobs that can be buffered in the channel
 // while waiting to be executed. Jobs beyond this limit are rejected — the
 // server will retry them on the next reconnect via DispatchPending.
@@ -276,7 +283,15 @@ func (e *Executor) executeBackup(ctx context.Context, job JobAssignment, sink Lo
 	// --- 4. Pre-backup hook ---
 	if payload.HookPreBackup != "" {
 		log("info", fmt.Sprintf("running pre-backup hook: %s", payload.HookPreBackup))
-		result, err := e.hooks.Run(ctx, payload.HookPreBackup)
+
+		hook, err := e.resolveHook(ctx, payload.HookPreBackup)
+		if err != nil {
+			fail(fmt.Sprintf("failed to resolve pre-backup hook: %v", err))
+			return
+		}
+
+		result, err := e.hooks.Run(ctx, hook.Command, hook.Args, time.Duration(hook.TimeoutSecs)*time.Second)
+		
 		if result.Output != "" {
 			log("info", "pre-backup hook output: "+result.Output)
 		}
@@ -391,7 +406,14 @@ func (e *Executor) executeBackup(ctx context.Context, job JobAssignment, sink Lo
 	// --- 6. Post-backup hook (always runs) ---
 	if payload.HookPostBackup != "" {
 		log("info", fmt.Sprintf("running post-backup hook: %s", payload.HookPostBackup))
-		result, _ := e.hooks.Run(ctx, payload.HookPostBackup)
+
+		hook, err := e.resolveHook(ctx, payload.HookPostBackup)
+		if err != nil {
+			fail(fmt.Sprintf("failed to resolve post-backup hook: %v", err))
+			return
+		}
+
+		result, _ := e.hooks.Run(ctx, hook.Command, hook.Args, time.Duration(hook.TimeoutSecs)*time.Second)
 		if result.Output != "" {
 			log("info", "post-backup hook output: "+result.Output)
 		}
@@ -622,4 +644,13 @@ func (e *Executor) resolveSources(ctx context.Context, sourcesJSON string, log f
 	}
 
 	return resolved, nil
+}
+
+func (e *Executor) resolveHook(ctx context.Context, hookJSON string) (*hookPayload, error) {
+	var hook hookPayload
+	if err := json.Unmarshal([]byte(hookJSON), &hook); err != nil {
+		return nil, fmt.Errorf("invalid hook JSON: %w", err)
+	}
+
+	return &hook, nil
 }

--- a/agent/internal/hooks/runner.go
+++ b/agent/internal/hooks/runner.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 )
 
@@ -69,18 +70,24 @@ func NewRunner(timeout time.Duration) *Runner {
 // A non-zero exit code returns ErrHookFailed wrapping the underlying
 // exec.ExitError — the Result is still populated so the caller can log
 // the output regardless.
-func (r *Runner) Run(ctx context.Context, command string) (*Result, error) {
+func (r *Runner) Run(ctx context.Context, command string, args []string, timeout time.Duration) (*Result, error) {
 	if command == "" {
 		// No hook configured — treat as success with no output.
 		return &Result{}, nil
 	}
 
-	// Apply the runner timeout on top of any deadline already in ctx.
+	timeoutToUse := r.Timeout
+
+	if timeout > 0 {
+		timeoutToUse = timeout
+	}
+
+	// Apply the command timeout (or the runner if it's zero) on top of any deadline already in ctx.
 	// context.WithTimeout returns the shorter of the two deadlines.
-	ctx, cancel := context.WithTimeout(ctx, r.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, timeoutToUse)
 	defer cancel()
 
-	cmd := buildShellCmd(ctx, command)
+	cmd := buildShellCmd(ctx, command, args, timeout)
 
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
@@ -130,9 +137,16 @@ func (r *Runner) Run(ctx context.Context, command string) (*Result, error) {
 // hooks can use pipes, environment variable expansion, conditionals, and
 // other shell features — consistent with what users expect from a "shell
 // command" field in the GUI.
-func buildShellCmd(ctx context.Context, command string) *exec.Cmd {
-	if runtime.GOOS == "windows" {
-		return exec.CommandContext(ctx, "cmd", "/C", command)
+func buildShellCmd(ctx context.Context, command string, args []string, timeout time.Duration) *exec.Cmd {
+
+	shellCmd := command
+
+	if len(args) > 0 {
+		shellCmd = shellCmd + " " + strings.Join(args, " ")
 	}
-	return exec.CommandContext(ctx, "/bin/sh", "-c", command)
+
+	if runtime.GOOS == "windows" {
+		return exec.CommandContext(ctx, "cmd", "/C", shellCmd)
+	}
+	return exec.CommandContext(ctx, "/bin/sh", "-c", shellCmd)
 }

--- a/gui/src/components/policies/PolicySheet.vue
+++ b/gui/src/components/policies/PolicySheet.vue
@@ -1,27 +1,20 @@
 <script setup lang="ts">
-import { ref, watch, computed } from 'vue'
-import { useForm, useField, useFieldArray } from 'vee-validate'
-import { toTypedSchema } from '@vee-validate/zod'
-import * as z from 'zod'
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetFooter,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import {
   Field,
   FieldError,
   FieldGroup,
   FieldLabel,
 } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -30,28 +23,35 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
-import { Badge } from '@/components/ui/badge'
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible'
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Switch } from '@/components/ui/switch'
+import { api } from '@/services/api'
+import { useAuthStore } from '@/stores/auth'
+import type { Agent, ApiResponse, Destination, Policy, VolumeInfo } from '@/types'
+import { toTypedSchema } from '@vee-validate/zod'
 import {
   AlertCircle,
   AlertTriangle,
-  Loader2,
-  Plus,
-  Trash2,
-  ChevronUp,
   ChevronDown,
   ChevronRight,
+  ChevronUp,
   Eye,
   EyeOff,
+  Loader2,
+  Plus,
   RefreshCw,
+  Trash2,
 } from 'lucide-vue-next'
-import { api } from '@/services/api'
-import type { ApiResponse, Policy, Agent, Destination, VolumeInfo } from '@/types'
-import { useAuthStore } from '@/stores/auth'
+import { useField, useFieldArray, useForm } from 'vee-validate'
+import { computed, ref, watch } from 'vue'
+import * as z from 'zod'
 
 const authStore = useAuthStore()
 
@@ -493,10 +493,17 @@ watch(
 // ---------------------------------------------------------------------------
 
 function populateForm(p: Policy) {
-  let parsedSources: { type: string; path: string; label?: string }[] = []
+  let parsedSources: RawSource[] = []
+  let parsedPreHook: RawHook | null = null
+  let parsedPostHook: RawHook | null = null
+
   try {
     parsedSources = typeof p.sources === 'string' ? JSON.parse(p.sources) : (p.sources ?? [])
+    parsedPreHook = typeof p.hook_pre_backup === "string" ? JSON.parse(p.hook_pre_backup) : null
+    parsedPostHook = typeof p.hook_post_backup === "string" ? JSON.parse(p.hook_post_backup) : null
   } catch { /* fallback to empty */ }
+
+  type RawHook = {name: string, command: string, args: string[], timeout_secs: number}
 
   // Re-group docker-volume entries that were expanded on save back into a
   // single source row per group. Two entries belong to the same group when
@@ -563,8 +570,8 @@ function populateForm(p: Policy) {
     retention_keep_monthly: p.retention_monthly ?? 6,
     retention_keep_yearly: p.retention_yearly ?? 1,
     ordered_destination_ids: preDestIds,
-    hook_pre: { enabled: false, name: '', command: '', args: '', timeout_secs: 30 },
-    hook_post: { enabled: false, name: '', command: '', args: '', timeout_secs: 30 },
+    hook_pre: parsedPreHook === null ? { enabled: false, name: '', command: '', args: '', timeout_secs: 30 } : { enabled: true, ...parsedPreHook, args: parsedPreHook.args.join(" ") },
+    hook_post: parsedPostHook === null ? { enabled: false, name: '', command: '', args: '', timeout_secs: 30 } : { enabled: true, ...parsedPostHook, args: parsedPostHook.args.join(" ") },
   } as unknown as FormValues)
 
   const match = SCHEDULE_PRESETS.find(s => s.value === p.schedule)


### PR DESCRIPTION
(Sorry, I had created a pull request before this one, but I compared it to “main” instead of “develop”)

Fix: the problem of agent trying to interpret the serialized JSON of the hook insted of parsing it
Fix: the agent wasn't  taking hook timeout in account.
Fix: the gui wasn't displaying saved hooks in policy sheet

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues
https://github.com/arkeep-io/arkeep/issues/71