### PR TITLE
fix: normalize browse error responses and pre-select original agent

### DIFF
--- a/gui/src/components/snapshots/RestoreSheet.vue
+++ b/gui/src/components/snapshots/RestoreSheet.vue
@@ -138,6 +138,10 @@ watch(
         selectedPaths.value = []
         browseError.value = null
         await fetchAgents()
+        // Pre-select the snapshot's original agent if it's online.
+        if (props.snapshot?.agent_id && agents.value.some((a) => a.id === props.snapshot?.agent_id)) {
+            agentId.value = props.snapshot.agent_id
+        }
     },
 )
 
@@ -179,7 +183,7 @@ async function browseSnapshot() {
         browseEntries.value = res.data.entries ?? []
         selectedPaths.value = []
     } catch (e: any) {
-        browseError.value = e?.data?.error ?? e?.message ?? 'Failed to browse snapshot.'
+        browseError.value = e?.data?.error?.message ?? e?.message ?? 'Failed to browse snapshot.'
     } finally {
         isBrowsing.value = false
     }

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -244,6 +244,8 @@ export interface Snapshot {
   policy_name: string // denormalized for display
   destination_id: string
   destination_name: string // denormalized for display
+  agent_id: string
+  agent_name: string
   restic_snapshot_id: string // the actual Restic snapshot hash
   hostname: string
   paths: string[]

--- a/server/internal/api/snapshots.go
+++ b/server/internal/api/snapshots.go
@@ -64,6 +64,8 @@ type snapshotResponse struct {
 	PolicyName       string `json:"policy_name"`
 	DestinationID    string `json:"destination_id"`
 	DestinationName  string `json:"destination_name"`
+	AgentID          string `json:"agent_id"`
+	AgentName        string `json:"agent_name"`
 	JobID            string `json:"job_id"`
 	ResticSnapshotID string `json:"restic_snapshot_id"`
 	SizeBytes        int64  `json:"size_bytes"`
@@ -137,6 +139,8 @@ func snapshotWithNamesToResponse(s repositories.SnapshotWithNames) snapshotRespo
 		PolicyName:       s.PolicyName,
 		DestinationID:    s.DestinationID.String(),
 		DestinationName:  s.DestinationName,
+		AgentID:          s.AgentID,
+		AgentName:        s.AgentName,
 		JobID:            s.JobID.String(),
 		ResticSnapshotID: s.SnapshotID,
 		SizeBytes:        s.SizeBytes,
@@ -477,7 +481,7 @@ func (h *SnapshotHandler) Browse(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, agentmanager.ErrAgentNotConnected):
 			ErrServiceUnavailable(w, "agent is not connected")
 		case errors.Is(err, agentmanager.ErrSnapshotBrowseTimeout):
-			http.Error(w, `{"error":"snapshot browse timed out"}`, http.StatusGatewayTimeout)
+			errJSON(w, http.StatusGatewayTimeout, "snapshot browse timed out", "gateway_timeout")
 		default:
 			h.logger.Error("snapshot browse failed", zap.Error(err))
 			ErrInternal(w)
@@ -486,7 +490,7 @@ func (h *SnapshotHandler) Browse(w http.ResponseWriter, r *http.Request) {
 	}
 	if result.Err != "" {
 		h.logger.Warn("agent reported error during snapshot browse", zap.String("error", result.Err))
-		http.Error(w, `{"error":"`+result.Err+`"}`, http.StatusBadGateway)
+		errJSON(w, http.StatusBadGateway, result.Err, "agent_error")
 		return
 	}
 

--- a/server/internal/repositories/snapshot.go
+++ b/server/internal/repositories/snapshot.go
@@ -17,6 +17,8 @@ type SnapshotWithNames struct {
 	db.Snapshot
 	PolicyName      string
 	DestinationName string
+	AgentID         string
+	AgentName       string
 }
 
 // gormSnapshotRepository is the GORM implementation of SnapshotRepository.
@@ -75,10 +77,13 @@ func (r *gormSnapshotRepository) listWithNamesQuery(ctx context.Context) *gorm.D
 	return r.db.WithContext(ctx).
 		Table("snapshots").
 		Select(`snapshots.*,
-			policies.name   AS policy_name,
-			destinations.name AS destination_name`).
+			policies.name        AS policy_name,
+			destinations.name    AS destination_name,
+			policies.agent_id    AS agent_id,
+			agents.name          AS agent_name`).
 		Joins("LEFT JOIN policies ON policies.id = snapshots.policy_id").
 		Joins("LEFT JOIN destinations ON destinations.id = snapshots.destination_id").
+		Joins("LEFT JOIN agents ON agents.id = policies.agent_id").
 		Order("snapshots.snapshot_at DESC")
 }
 


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)
