### PR TITLE
feat: enable VSS snapshots on Windows for locked-file backups

### DIFF
--- a/agent/internal/restic/wrapper.go
+++ b/agent/internal/restic/wrapper.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -179,13 +180,16 @@ func (w *Wrapper) Init(ctx context.Context, dest Destination) error {
 // Returns a BackupResult with snapshot metadata extracted from the restic
 // summary event, and an error if the backup fails. A non-zero restic exit
 // code is always wrapped in the returned error with stderr included.
-func (w *Wrapper) Backup(ctx context.Context, dest Destination, opts BackupOptions, onProgress ProgressFunc) (*BackupResult, error) {
-	if err := w.Init(ctx, dest); err != nil {
-		return nil, fmt.Errorf("restic: failed to init repository: %w", err)
-	}
-
+// buildBackupArgs constructs the restic backup argument slice for the given
+// options. goos mirrors runtime.GOOS and is a parameter so the function can
+// be tested without cross-compiling.
+func buildBackupArgs(opts BackupOptions, goos string) []string {
 	args := []string{"backup", "--json"}
-
+	if goos == "windows" {
+		// VSS creates a consistent snapshot of locked/in-use files.
+		// Requires the agent to run with Administrator privileges.
+		args = append(args, "--use-fs-snapshot")
+	}
 	for _, tag := range opts.Tags {
 		args = append(args, "--tag", tag)
 	}
@@ -193,6 +197,15 @@ func (w *Wrapper) Backup(ctx context.Context, dest Destination, opts BackupOptio
 		args = append(args, "--exclude", ex)
 	}
 	args = append(args, opts.Sources...)
+	return args
+}
+
+func (w *Wrapper) Backup(ctx context.Context, dest Destination, opts BackupOptions, onProgress ProgressFunc) (*BackupResult, error) {
+	if err := w.Init(ctx, dest); err != nil {
+		return nil, fmt.Errorf("restic: failed to init repository: %w", err)
+	}
+
+	args := buildBackupArgs(opts, runtime.GOOS)
 
 	var result BackupResult
 
@@ -360,6 +373,9 @@ func (w *Wrapper) runRestoreJSON(ctx context.Context, dest Destination, args []s
 	for scanner.Scan() {
 		// discard
 	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("restic: failed to read stdout: %w", err)
+	}
 
 	if err := cmd.Wait(); err != nil {
 		stderr := strings.TrimSpace(stderrBuf.String())
@@ -513,6 +529,9 @@ func (w *Wrapper) runWithProgress(ctx context.Context, dest Destination, args []
 				return fmt.Errorf("restic: progress callback cancelled: %w", err)
 			}
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("restic: failed to read stdout: %w", err)
 	}
 
 	if err := cmd.Wait(); err != nil {

--- a/agent/internal/restic/wrapper_test.go
+++ b/agent/internal/restic/wrapper_test.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -38,6 +39,30 @@ func TestBuildCmd_S3Repository(t *testing.T) {
 	}
 	if !strings.HasPrefix(repoURL, "s3:") {
 		t.Errorf("RESTIC_REPOSITORY=%q, want prefix 's3:'", repoURL)
+	}
+}
+
+func TestBuildBackupArgs_Windows(t *testing.T) {
+	opts := BackupOptions{
+		Tags:    []string{"weekly"},
+		Sources: []string{`C:\Users`},
+	}
+	args := buildBackupArgs(opts, "windows")
+
+	if !slices.Contains(args, "--use-fs-snapshot") {
+		t.Errorf("expected --use-fs-snapshot in args on windows, got %v", args)
+	}
+}
+
+func TestBuildBackupArgs_Linux(t *testing.T) {
+	opts := BackupOptions{
+		Tags:    []string{"weekly"},
+		Sources: []string{"/home"},
+	}
+	args := buildBackupArgs(opts, "linux")
+
+	if slices.Contains(args, "--use-fs-snapshot") {
+		t.Errorf("unexpected --use-fs-snapshot in args on linux, got %v", args)
 	}
 }
 


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues

Closes #116 
