### PR TITLE
fix: widen job_destinations.size_bytes to bigint on PostgreSQL

### DIFF
--- a/server/internal/db/migrations/postgres/000013_job_destinations_size_bytes_bigint.down.sql
+++ b/server/internal/db/migrations/postgres/000013_job_destinations_size_bytes_bigint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_destinations ALTER COLUMN size_bytes TYPE integer;

--- a/server/internal/db/migrations/postgres/000013_job_destinations_size_bytes_bigint.up.sql
+++ b/server/internal/db/migrations/postgres/000013_job_destinations_size_bytes_bigint.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job_destinations ALTER COLUMN size_bytes TYPE bigint;


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues

Closes #110 
