### PR TITLE
fix: map "cancelled" status to JOB_STATUS_CANCELLED in statusToProto

### DIFF
--- a/agent/internal/connection/manager.go
+++ b/agent/internal/connection/manager.go
@@ -862,7 +862,7 @@ func (m *Manager) closeLogStream(jobID string) {
 // ReportStatus implements executor.StatusReporter. It calls ReportJobStatus
 // via gRPC and manages the log stream lifecycle:
 //   - "running"          → opens the log stream before reporting
-//   - "success"/"failed" → reports status then closes the log stream
+//   - "succeeded"/"failed" → reports status then closes the log stream
 func (m *Manager) ReportStatus(jobID, status, message string) {
 	if status == "running" {
 		m.openLogStream(jobID)
@@ -895,7 +895,7 @@ func (m *Manager) ReportStatus(jobID, status, message string) {
 		)
 	}
 
-	if status == "success" || status == "failed" || status == "cancelled" {
+	if status == "succeeded" || status == "failed" || status == "cancelled" {
 		m.closeLogStream(jobID)
 	}
 }
@@ -981,10 +981,12 @@ func statusToProto(status string) proto.JobStatus {
 	switch status {
 	case "running":
 		return proto.JobStatus_JOB_STATUS_RUNNING
-	case "success":
+	case "succeeded":
 		return proto.JobStatus_JOB_STATUS_COMPLETED
 	case "failed":
 		return proto.JobStatus_JOB_STATUS_FAILED
+	case "cancelled":
+		return proto.JobStatus_JOB_STATUS_CANCELLED
 	default:
 		return proto.JobStatus_JOB_STATUS_UNSPECIFIED
 	}

--- a/agent/internal/executor/executor.go
+++ b/agent/internal/executor/executor.go
@@ -528,7 +528,7 @@ func (e *Executor) executeBackup(ctx context.Context, job JobAssignment, sink Lo
 	}
 
 	log("info", "backup completed successfully")
-	reporter.ReportStatus(job.JobID, "success", "backup completed")
+	reporter.ReportStatus(job.JobID, "succeeded", "backup completed")
 }
 
 // executeRestore runs a single restore job to completion.
@@ -635,7 +635,7 @@ func (e *Executor) executeRestore(ctx context.Context, job JobAssignment, sink L
 
 	// --- 5. Final status ---
 	log("info", fmt.Sprintf("restore completed successfully: files written to %s", targetPath))
-	reporter.ReportStatus(job.JobID, "success", "restore completed")
+	reporter.ReportStatus(job.JobID, "succeeded", "restore completed")
 }
 
 // buildInPlaceExcludes returns the --exclude paths for an in-place restore.


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)