### PR TITLE
fix: browse large snapshots one directory at a time #175

### DIFF
--- a/agent/internal/connection/manager.go
+++ b/agent/internal/connection/manager.go
@@ -647,7 +647,10 @@ func (m *Manager) handleVolumeListRequest(correlationID, agentID string) {
 type snapshotBrowsePayload struct {
 	ResticSnapshotID string `json:"restic_snapshot_id"`
 	RepoPassword     string `json:"repo_password"`
-	Destination      struct {
+	// Path is the directory whose direct children should be listed. Empty means
+	// the snapshot root. The GUI sends one path per directory it expands.
+	Path        string `json:"path"`
+	Destination struct {
 		Type    string            `json:"type"`
 		RepoURL string            `json:"repo_url"`
 		Env     map[string]string `json:"env"`
@@ -698,7 +701,7 @@ func (m *Manager) handleSnapshotBrowseRequest(correlationID, agentID string, pay
 		Env:      p.Destination.Env,
 	}
 
-	entries, err := m.wrapper.Ls(ctx, dest, p.ResticSnapshotID)
+	entries, err := m.wrapper.Ls(ctx, dest, p.ResticSnapshotID, p.Path)
 	if err != nil {
 		report.Error = err.Error()
 	} else {

--- a/agent/internal/restic/wrapper.go
+++ b/agent/internal/restic/wrapper.go
@@ -312,11 +312,18 @@ func (w *Wrapper) Restore(ctx context.Context, dest Destination, snapshotID, tar
 	return w.runRestoreJSON(ctx, dest, args, hostRoot)
 }
 
-// Ls returns the list of files and directories stored in snapshotID.
-// It runs `restic ls --json <snapshotID>` and parses the newline-delimited
-// JSON output. The first line is the snapshot header and is skipped.
-func (w *Wrapper) Ls(ctx context.Context, dest Destination, snapshotID string) ([]LsEntry, error) {
-	cmd := w.buildCmd(ctx, dest, []string{"ls", "--json", snapshotID})
+// Ls returns the direct children of dir within snapshotID (non-recursive).
+// It runs `restic ls --json <snapshotID> <dir>` and parses the newline-delimited
+// JSON output. Without --recursive, restic lists only the immediate entries of
+// dir, which keeps the response small and fast even on huge snapshots (the GUI
+// expands one directory level at a time). The snapshot header line and the dir
+// entry itself are skipped, so the result is exactly the directory's children.
+// dir defaults to "/" (the snapshot root) when empty.
+func (w *Wrapper) Ls(ctx context.Context, dest Destination, snapshotID, dir string) ([]LsEntry, error) {
+	if dir == "" {
+		dir = "/"
+	}
+	cmd := w.buildCmd(ctx, dest, []string{"ls", "--json", snapshotID, dir})
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("restic: failed to open stdout pipe: %w", err)
@@ -348,6 +355,11 @@ func (w *Wrapper) Ls(ctx context.Context, dest Destination, snapshotID string) (
 			Mtime string `json:"mtime"`
 		}
 		if err := json.Unmarshal(line, &raw); err != nil {
+			continue
+		}
+		if raw.Path == dir {
+			// restic emits the queried directory itself; skip it so the result
+			// contains only its direct children.
 			continue
 		}
 		entries = append(entries, LsEntry{

--- a/gui/src/components/snapshots/RestoreSheet.vue
+++ b/gui/src/components/snapshots/RestoreSheet.vue
@@ -173,21 +173,31 @@ watch(selectedAgent, (agent) => {
 // Data fetching
 // ---------------------------------------------------------------------------
 
+// browseSnapshot loads the snapshot's top-level directories. Deeper levels are
+// fetched lazily by the file tree via loadChildren as the user expands them.
 async function browseSnapshot() {
     if (!props.snapshot) return
     isBrowsing.value = true
     browseError.value = null
     try {
-        const res = await api<{ data: { entries: SnapshotFileEntry[] } }>(
-            `/api/v1/snapshots/${props.snapshot.id}/browse`,
-        )
-        browseEntries.value = res.data.entries ?? []
+        browseEntries.value = await loadChildren('')
         selectedPaths.value = []
     } catch (e: any) {
         browseError.value = e?.data?.error?.message ?? e?.message ?? 'Failed to browse snapshot.'
     } finally {
         isBrowsing.value = false
     }
+}
+
+// loadChildren fetches the direct children of one directory within the snapshot.
+// An empty path lists the snapshot root.
+async function loadChildren(path: string): Promise<SnapshotFileEntry[]> {
+    if (!props.snapshot) return []
+    const query = path ? `?path=${encodeURIComponent(path)}` : ''
+    const res = await api<{ data: { entries: SnapshotFileEntry[] } }>(
+        `/api/v1/snapshots/${props.snapshot.id}/browse${query}`,
+    )
+    return res.data.entries ?? []
 }
 
 // ---------------------------------------------------------------------------
@@ -336,6 +346,7 @@ function onOpenChange(value: boolean) {
                             <SnapshotFileTree
                                 v-model="selectedPaths"
                                 :entries="browseEntries"
+                                :load-children="loadChildren"
                                 class="max-h-64 overflow-y-auto rounded border"
                             />
                         </div>

--- a/gui/src/components/snapshots/SnapshotFileTree.vue
+++ b/gui/src/components/snapshots/SnapshotFileTree.vue
@@ -1,101 +1,134 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { ChevronRight, ChevronDown, Folder, FolderOpen, File } from '@lucide/vue'
+import { ChevronRight, ChevronDown, Folder, FolderOpen, File, Loader2 } from '@lucide/vue'
 import type { SnapshotFileEntry } from '@/types'
 
 const props = defineProps<{
+  // entries are the root-level children of the snapshot (its top directories).
   entries: SnapshotFileEntry[]
   modelValue: string[]
+  // loadChildren fetches the direct children of a directory on demand. The tree
+  // loads one level at a time so huge snapshots stay responsive.
+  loadChildren: (path: string) => Promise<SnapshotFileEntry[]>
 }>()
 
 const emit = defineEmits<{
   'update:modelValue': [value: string[]]
 }>()
 
-// collapsed keeps track of which directory paths are collapsed.
-const collapsed = ref(new Set<string>())
+// Lazy-loading state, keyed by directory path.
+const childrenByPath = ref(new Map<string, SnapshotFileEntry[]>())
+const expanded = ref(new Set<string>())
+const loading = ref(new Set<string>())
+const errors = ref(new Map<string, string>())
 
-// Start with all directories collapsed whenever entries are (re)loaded.
-watch(() => props.entries, (entries) => {
-  collapsed.value = new Set(entries.filter(e => e.type === 'dir').map(e => e.path))
-}, { immediate: true })
-
-function toggleDir(path: string) {
-  if (collapsed.value.has(path)) {
-    collapsed.value.delete(path)
-  } else {
-    collapsed.value.add(path)
-  }
-  // trigger reactivity
-  collapsed.value = new Set(collapsed.value)
-}
-
-// A flat row is derived from the entry list: sort dirs before files at each level,
-// then filter out rows whose ancestor dirs are collapsed.
-const rows = computed(() => {
-  const sorted = [...props.entries].sort((a, b) => {
-    const pa = a.path.split('/')
-    const pb = b.path.split('/')
-    // compare level by level
-    for (let i = 0; i < Math.min(pa.length, pb.length); i++) {
-      if (pa[i] !== pb[i]) {
-        return pa[i].localeCompare(pb[i])
-      }
-    }
-    return pa.length - pb.length
-  })
-
-  // Stable sort: dirs before files within the same parent
-  sorted.sort((a, b) => {
-    const aParent = a.path.substring(0, a.path.lastIndexOf('/'))
-    const bParent = b.path.substring(0, b.path.lastIndexOf('/'))
-    if (aParent !== bParent) return 0
-    if (a.type === b.type) return 0
-    return a.type === 'dir' ? -1 : 1
-  })
-
-  return sorted.filter(e => {
-    // hide if any ancestor directory is collapsed
-    const parts = e.path.split('/')
-    for (let i = 1; i < parts.length - 1; i++) {
-      const ancestor = parts.slice(0, i + 1).join('/')
-      if (collapsed.value.has(ancestor)) return false
-    }
-    return true
-  })
+// Reset all internal state whenever a fresh root listing is loaded.
+watch(() => props.entries, () => {
+  childrenByPath.value = new Map()
+  expanded.value = new Set()
+  loading.value = new Set()
+  errors.value = new Map()
 })
 
-function depth(path: string): number {
-  return path.split('/').length - 2 // root "/" counts as -1
-}
-
 function name(path: string): string {
-  return path.split('/').pop() ?? path
+  return path.split('/').pop() || path
 }
 
-function isSelected(path: string): boolean {
-  return props.modelValue.includes(path)
+function sortEntries(entries: SnapshotFileEntry[]): SnapshotFileEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.type !== b.type) return a.type === 'dir' ? -1 : 1
+    return name(a.path).localeCompare(name(b.path))
+  })
+}
+
+interface Row {
+  entry: SnapshotFileEntry
+  depth: number
+}
+
+// rows flattens the currently-expanded tree into ordered display rows. Depth is
+// the walk level (not the path length) so deeply-rooted sources aren't
+// over-indented.
+const rows = computed<Row[]>(() => {
+  const out: Row[] = []
+  const walk = (entries: SnapshotFileEntry[], depth: number) => {
+    for (const entry of sortEntries(entries)) {
+      out.push({ entry, depth })
+      if (entry.type === 'dir' && expanded.value.has(entry.path)) {
+        const children = childrenByPath.value.get(entry.path)
+        if (children) walk(children, depth + 1)
+      }
+    }
+  }
+  walk(props.entries, 0)
+  return out
+})
+
+async function toggleDir(entry: SnapshotFileEntry) {
+  const path = entry.path
+  if (expanded.value.has(path)) {
+    expanded.value.delete(path)
+    expanded.value = new Set(expanded.value)
+    return
+  }
+
+  expanded.value.add(path)
+  expanded.value = new Set(expanded.value)
+
+  // Fetch children the first time the directory is expanded.
+  if (!childrenByPath.value.has(path) && !loading.value.has(path)) {
+    loading.value.add(path)
+    loading.value = new Set(loading.value)
+    errors.value.delete(path)
+    errors.value = new Map(errors.value)
+    try {
+      const children = await props.loadChildren(path)
+      childrenByPath.value.set(path, children)
+      childrenByPath.value = new Map(childrenByPath.value)
+    } catch (e: any) {
+      errors.value.set(path, e?.data?.error?.message ?? e?.message ?? 'Failed to load directory.')
+      errors.value = new Map(errors.value)
+      // Collapse again so the chevron offers a retry.
+      expanded.value.delete(path)
+      expanded.value = new Set(expanded.value)
+    } finally {
+      loading.value.delete(path)
+      loading.value = new Set(loading.value)
+    }
+  }
+}
+
+// --- Selection ---------------------------------------------------------------
+// Selecting a directory records only its own path: restic restore --include
+// restores a directory recursively, so descendants need not be enumerated.
+
+function ancestorSelected(path: string): boolean {
+  return props.modelValue.some(p => path.startsWith(p + '/'))
+}
+
+function isChecked(path: string): boolean {
+  return props.modelValue.includes(path) || ancestorSelected(path)
 }
 
 function isIndeterminate(entry: SnapshotFileEntry): boolean {
-  if (entry.type !== 'dir' || isSelected(entry.path)) return false
+  if (entry.type !== 'dir' || isChecked(entry.path)) return false
   const prefix = entry.path + '/'
-  const descendants = props.entries.filter(e => e.path.startsWith(prefix))
-  const selectedCount = descendants.filter(e => props.modelValue.includes(e.path)).length
-  return selectedCount > 0 && selectedCount < descendants.length
+  return props.modelValue.some(p => p.startsWith(prefix))
 }
 
 function toggle(entry: SnapshotFileEntry) {
-  if (isSelected(entry.path)) {
-    // deselect this entry and all its descendants
-    const prefix = entry.path + '/'
-    emit('update:modelValue', props.modelValue.filter(p => p !== entry.path && !p.startsWith(prefix)))
+  const path = entry.path
+  // A node whose ancestor is selected is locked; change the ancestor instead.
+  if (ancestorSelected(path)) return
+
+  const prefix = path + '/'
+  if (props.modelValue.includes(path)) {
+    emit('update:modelValue', props.modelValue.filter(p => p !== path && !p.startsWith(prefix)))
   } else {
-    // select this entry and all its descendants
-    const toAdd = entry.type === 'dir'
-      ? props.entries.filter(e => e.path === entry.path || e.path.startsWith(entry.path + '/')).map(e => e.path)
-      : [entry.path]
-    emit('update:modelValue', [...new Set([...props.modelValue, ...toAdd])])
+    // Drop now-redundant descendant selections, then add this path.
+    const next = props.modelValue.filter(p => !p.startsWith(prefix))
+    next.push(path)
+    emit('update:modelValue', [...new Set(next)])
   }
 }
 </script>
@@ -103,19 +136,20 @@ function toggle(entry: SnapshotFileEntry) {
 <template>
   <div class="font-mono text-xs">
     <div
-      v-for="entry in rows"
+      v-for="{ entry, depth } in rows"
       :key="entry.path"
       class="flex items-center gap-1 py-0.5 px-1 hover:bg-muted/50 select-none"
-      :style="{ paddingLeft: `${8 + depth(entry.path) * 16}px` }"
+      :style="{ paddingLeft: `${8 + depth * 16}px` }"
     >
-      <!-- dir chevron -->
+      <!-- dir chevron / loading spinner -->
+      <Loader2 v-if="entry.type === 'dir' && loading.has(entry.path)" class="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
       <button
-        v-if="entry.type === 'dir'"
+        v-else-if="entry.type === 'dir'"
         type="button"
         class="shrink-0 p-0 text-muted-foreground"
-        @click.stop="toggleDir(entry.path)"
+        @click.stop="toggleDir(entry)"
       >
-        <ChevronDown v-if="!collapsed.has(entry.path)" class="h-3.5 w-3.5" />
+        <ChevronDown v-if="expanded.has(entry.path)" class="h-3.5 w-3.5" />
         <ChevronRight v-else class="h-3.5 w-3.5" />
       </button>
       <span v-else class="w-3.5 shrink-0" />
@@ -123,20 +157,26 @@ function toggle(entry: SnapshotFileEntry) {
       <!-- checkbox -->
       <input
         type="checkbox"
-        :checked="isSelected(entry.path)"
+        :checked="isChecked(entry.path)"
         :indeterminate="isIndeterminate(entry)"
-        class="h-3.5 w-3.5 shrink-0 accent-primary cursor-pointer"
+        :disabled="ancestorSelected(entry.path)"
+        class="h-3.5 w-3.5 shrink-0 accent-primary cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
         @change="toggle(entry)"
       />
 
       <!-- icon -->
-      <FolderOpen v-if="entry.type === 'dir' && !collapsed.has(entry.path)" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <FolderOpen v-if="entry.type === 'dir' && expanded.has(entry.path)" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       <Folder v-else-if="entry.type === 'dir'" class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       <File v-else class="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
 
       <!-- name -->
-      <span class="truncate cursor-pointer" @click="entry.type === 'dir' ? toggleDir(entry.path) : toggle(entry)">
+      <span class="truncate cursor-pointer" @click="entry.type === 'dir' ? toggleDir(entry) : toggle(entry)">
         {{ name(entry.path) }}
+      </span>
+
+      <!-- per-directory load error -->
+      <span v-if="errors.has(entry.path)" class="ml-2 text-destructive truncate">
+        {{ errors.get(entry.path) }}
       </span>
     </div>
   </div>

--- a/server/internal/agentmanager/manager.go
+++ b/server/internal/agentmanager/manager.go
@@ -42,8 +42,9 @@ var ErrSnapshotImportTimeout = errors.New("snapshot import request timed out")
 const volumeListTimeout = 10 * time.Second
 
 // snapshotBrowseTimeout is how long RequestSnapshotBrowse waits for the agent.
-// Generous because restic ls on a remote repository can take tens of seconds.
-const snapshotBrowseTimeout = 60 * time.Second
+// Generous because the first directory expansion loads the repository index,
+// which can take minutes on a large remote (e.g. rclone/pCloud) repository.
+const snapshotBrowseTimeout = 5 * time.Minute
 
 // snapshotImportTimeout is how long RequestSnapshotImport waits for the agent.
 // Generous because restic snapshots on a large remote repository can be slow.

--- a/server/internal/api/destinations.go
+++ b/server/internal/api/destinations.go
@@ -181,6 +181,11 @@ func (h *DestinationHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ErrInternal(w)
 			return
 		}
+		// Listing snapshots on a cold remote repository can exceed the server's
+		// default 30s write timeout; extend it so the response isn't severed.
+		if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(5 * time.Minute)); err != nil {
+			h.logger.Debug("import: could not extend write deadline", zap.Error(err))
+		}
 		correlationID := uuid.New().String()
 		res, err := h.agentMgr.RequestSnapshotImport(ctx, req.ImportAgentID, correlationID, payloadBytes)
 		if err != nil {
@@ -379,6 +384,11 @@ func (h *DestinationHandler) Import(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Listing snapshots on a cold remote repository can exceed the server's
+	// default 30s write timeout; extend it so the response isn't severed.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(5 * time.Minute)); err != nil {
+		h.logger.Debug("import: could not extend write deadline", zap.Error(err))
+	}
 	correlationID := uuid.New().String()
 	result, err := h.agentMgr.RequestSnapshotImport(ctx, req.AgentID, correlationID, payloadBytes)
 	if err != nil {

--- a/server/internal/api/snapshots.go
+++ b/server/internal/api/snapshots.go
@@ -108,6 +108,7 @@ type restorePayload struct {
 type snapshotBrowsePayload struct {
 	ResticSnapshotID string            `json:"restic_snapshot_id"`
 	RepoPassword     string            `json:"repo_password"`
+	Path             string            `json:"path"` // directory to list; empty means the snapshot root
 	Destination      destinationFields `json:"destination"`
 }
 
@@ -417,17 +418,21 @@ func (h *SnapshotHandler) Restore(w http.ResponseWriter, r *http.Request) {
 	Ok(w, restoreResponse{JobID: job.ID.String()})
 }
 
-// Browse handles GET /api/v1/snapshots/{id}/browse.
-// Returns the full file/directory tree of the snapshot by dispatching a
-// JOB_TYPE_LIST_SNAPSHOT_FILES request to the policy's agent via the existing
-// StreamJobs stream (same pattern as JOB_TYPE_LIST_VOLUMES).
+// Browse handles GET /api/v1/snapshots/{id}/browse[?path=<dir>].
+// Returns the direct children of one directory within the snapshot by
+// dispatching a JOB_TYPE_LIST_SNAPSHOT_FILES request to the policy's agent via
+// the existing StreamJobs stream (same pattern as JOB_TYPE_LIST_VOLUMES).
+//
+// The listing is non-recursive: the GUI expands one directory level at a time
+// (lazy loading), so each response stays small and fast even on snapshots with
+// millions of files. An empty path lists the snapshot root.
 //
 // Flow:
 //  1. Load snapshot → restic_snapshot_id, destination_id, policy_id
 //  2. Load policy → agent_id, repo_password
 //  3. Load destination → repo URL and env
-//  4. Dispatch browse request to agent; block until result or timeout (60 s)
-//  5. Return flat list of SnapshotFileEntry — the frontend builds the tree
+//  4. Dispatch browse request to agent; block until result or timeout
+//  5. Return the directory's direct children as a flat list of SnapshotFileEntry
 func (h *SnapshotHandler) Browse(w http.ResponseWriter, r *http.Request) {
 	snapshotID, ok := parseUUID(w, r, "id")
 	if !ok {
@@ -435,6 +440,7 @@ func (h *SnapshotHandler) Browse(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+	path := r.URL.Query().Get("path")
 
 	// --- 1. Load snapshot ---
 	snapshot, err := h.repo.GetByID(ctx, snapshotID)
@@ -482,6 +488,7 @@ func (h *SnapshotHandler) Browse(w http.ResponseWriter, r *http.Request) {
 	browsePayload := snapshotBrowsePayload{
 		ResticSnapshotID: snapshot.SnapshotID,
 		RepoPassword:     string(policy.RepoPassword),
+		Path:             path,
 		Destination: destinationFields{
 			DestinationID: dest.ID.String(),
 			Type:          dest.Type,
@@ -495,6 +502,14 @@ func (h *SnapshotHandler) Browse(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("failed to marshal browse payload", zap.Error(err))
 		ErrInternal(w)
 		return
+	}
+
+	// Running restic ls against a cold remote repository (the first expansion
+	// loads the index) can exceed the server's default 30s write timeout. Extend
+	// the write deadline past the agent wait (snapshotBrowseTimeout, 5m) so the
+	// response — success or the 504 — can always be written.
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Now().Add(6 * time.Minute)); err != nil {
+		h.logger.Debug("browse: could not extend write deadline", zap.Error(err))
 	}
 
 	correlationID := uuid.NewString()

--- a/server/internal/destutil/destutil.go
+++ b/server/internal/destutil/destutil.go
@@ -7,6 +7,7 @@ package destutil
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/arkeep-io/arkeep/server/internal/db"
 )
@@ -70,8 +71,18 @@ func BuildRepoURL(dest *db.Destination) string {
 	case "rclone":
 		var cfg struct {
 			Remote string `json:"remote"`
+			Path   string `json:"path"`
 		}
 		if err := json.Unmarshal([]byte(dest.Config), &cfg); err == nil && cfg.Remote != "" {
+			if cfg.Path != "" {
+				// rclone addresses a remote as "remote:path"; ensure exactly one
+				// colon separates them regardless of whether the user typed it.
+				remote := cfg.Remote
+				if !strings.HasSuffix(remote, ":") {
+					remote += ":"
+				}
+				return fmt.Sprintf("rclone:%s%s", remote, cfg.Path)
+			}
 			return fmt.Sprintf("rclone:%s", cfg.Remote)
 		}
 	}

--- a/server/internal/destutil/destutil_test.go
+++ b/server/internal/destutil/destutil_test.go
@@ -67,6 +67,18 @@ func TestBuildRepoURL(t *testing.T) {
 			config: `{"remote":"myremote:bucket"}`,
 			want:   "rclone:myremote:bucket",
 		},
+		{
+			name:   "rclone with path, remote has trailing colon",
+			dType:  "rclone",
+			config: `{"remote":"pCloudDrive:","path":"Arkeep"}`,
+			want:   "rclone:pCloudDrive:Arkeep",
+		},
+		{
+			name:   "rclone with path, remote without colon",
+			dType:  "rclone",
+			config: `{"remote":"pCloudDrive","path":"Arkeep"}`,
+			want:   "rclone:pCloudDrive:Arkeep",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues

Closes #175 
