### PR TITLE
fix: detect stale agents via heartbeat timeout and push live status

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/arkeep-io/arkeep/server/internal/agentmanager"
+	"github.com/arkeep-io/arkeep/server/internal/agentwatchdog"
 	"github.com/arkeep-io/arkeep/server/internal/api"
 	"github.com/arkeep-io/arkeep/server/internal/auth"
 	"github.com/arkeep-io/arkeep/server/internal/db"
@@ -263,6 +264,15 @@ func run(ctx context.Context, cfg *config) error {
 	// deletes rows once an administrator configures a retention window.
 	logRetentionSvc := logretention.NewService(jobRepo, settingsRepo, logger)
 	go logRetentionSvc.Start(ctx)
+
+	// --- Agent watchdog ---
+	// Detects agents that stopped sending heartbeats (network partition, crash,
+	// unplugged cable — anything that doesn't cleanly close the gRPC stream) and
+	// marks them offline. Without this, such an agent would stay "online"
+	// forever, since the only other trigger for "offline" is the StreamJobs
+	// stream actually closing.
+	agentWatchdogSvc := agentwatchdog.NewService(agentRepo, jobRepo, agentMgr, notifService, wsHub, logger)
+	go agentWatchdogSvc.Start(ctx)
 
 	// --- gRPC server ---
 	grpcSrv := grpcserver.New(

--- a/server/internal/agentwatchdog/service.go
+++ b/server/internal/agentwatchdog/service.go
@@ -1,0 +1,186 @@
+// Package agentwatchdog provides a background service that detects agents
+// which have stopped sending heartbeats and marks them offline.
+//
+// Without this service, an agent is only marked offline when its gRPC
+// StreamJobs stream closes — which relies on the underlying TCP connection
+// actually tearing down (a clean shutdown, or a same-network process kill that
+// makes the OS send a FIN). A network partition, a crashed host, or an
+// unplugged cable leaves no FIN to observe, so without an independent
+// timeout the agent would stay "online" forever. This service is that
+// timeout: it flips an agent offline once its last_seen_at is older than
+// staleTimeout, matching the heartbeat contract documented in
+// agent/internal/connection/manager.go (heartbeatInterval).
+package agentwatchdog
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/arkeep-io/arkeep/server/internal/db"
+	"github.com/arkeep-io/arkeep/server/internal/websocket"
+)
+
+const (
+	// heartbeatInterval mirrors agent/internal/connection/manager.go's constant
+	// of the same name — the agent sends a Heartbeat RPC at this cadence.
+	heartbeatInterval = 30 * time.Second
+
+	// staleTimeout is how long an online agent can go without a heartbeat
+	// before it is declared offline. 3x heartbeatInterval matches the contract
+	// already documented (but never implemented until this package) in
+	// agent/internal/connection/manager.go: "The server marks an agent offline
+	// if no heartbeat arrives within 3x this interval."
+	staleTimeout = 3 * heartbeatInterval
+
+	// runInterval is how often the watchdog sweeps for stale agents. Ticking at
+	// the same cadence as the heartbeat keeps worst-case detection latency
+	// bounded to roughly staleTimeout + runInterval.
+	runInterval = heartbeatInterval
+)
+
+// agentStore is the subset of the agent repository the watchdog needs.
+type agentStore interface {
+	ListStale(ctx context.Context, cutoff time.Time) ([]db.Agent, error)
+	MarkOfflineIfStale(ctx context.Context, id uuid.UUID, cutoff time.Time) (bool, error)
+}
+
+// jobStore is the subset of the job repository the watchdog needs for orphan
+// recovery — jobs left "running" by an agent that will never report a
+// terminal status again.
+type jobStore interface {
+	FailRunningJobsForAgent(ctx context.Context, agentID uuid.UUID, errMsg string) (int64, error)
+}
+
+// deregisterer removes an agent from the in-memory connection registry so the
+// scheduler stops dispatching new jobs to it. Implemented by *agentmanager.Manager.
+type deregisterer interface {
+	Deregister(agentID string)
+}
+
+// notifier sends the agent-offline notification. Implemented by
+// notification.Service.
+type notifier interface {
+	NotifyAgentOffline(ctx context.Context, agentID uuid.UUID, agentName string) error
+}
+
+// publisher pushes a live status update to subscribed GUI clients.
+// Implemented by *websocket.Hub.
+type publisher interface {
+	Publish(topic string, msg websocket.Message)
+}
+
+// Service periodically detects agents that stopped heartbeating and marks
+// them offline, running the same cleanup as a clean StreamJobs disconnect:
+// deregister, fail orphaned running jobs, send the offline notification, and
+// push a live status update to the GUI.
+type Service struct {
+	agents   agentStore
+	jobs     jobStore
+	registry deregisterer
+	notif    notifier // may be nil — notifications are then skipped
+	pub      publisher
+	logger   *zap.Logger
+}
+
+// NewService creates a stale-agent watchdog Service. notif may be nil, in
+// which case offline notifications are silently skipped (matching how the
+// gRPC server treats a nil notification.Service elsewhere in this codebase).
+func NewService(agents agentStore, jobs jobStore, registry deregisterer, notif notifier, pub publisher, logger *zap.Logger) *Service {
+	return &Service{
+		agents:   agents,
+		jobs:     jobs,
+		registry: registry,
+		notif:    notif,
+		pub:      pub,
+		logger:   logger.Named("agentwatchdog"),
+	}
+}
+
+// Start runs an initial sweep, then repeats every runInterval until ctx is
+// cancelled. Launch it as a goroutine:
+//
+//	go svc.Start(ctx)
+func (s *Service) Start(ctx context.Context) {
+	ticker := time.NewTicker(runInterval)
+	defer ticker.Stop()
+
+	// Initial sweep shortly after startup catches agents that were already
+	// stale before this server instance came up (e.g. after a restart).
+	s.RunOnce(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.RunOnce(ctx)
+		}
+	}
+}
+
+// RunOnce performs a single sweep for stale agents and returns how many were
+// flipped offline. Safe to call directly (e.g. from tests).
+func (s *Service) RunOnce(ctx context.Context) int {
+	cutoff := time.Now().UTC().Add(-staleTimeout)
+
+	candidates, err := s.agents.ListStale(ctx, cutoff)
+	if err != nil {
+		s.logger.Error("failed to list stale agents", zap.Error(err))
+		return 0
+	}
+
+	flipped := 0
+	for _, agent := range candidates {
+		ok, err := s.agents.MarkOfflineIfStale(ctx, agent.ID, cutoff)
+		if err != nil {
+			s.logger.Error("failed to mark agent offline",
+				zap.String("agent_id", agent.ID.String()),
+				zap.Error(err),
+			)
+			continue
+		}
+		if !ok {
+			// The agent sent a heartbeat between ListStale and this write —
+			// it is no longer stale. Not an error, just a closed race window.
+			continue
+		}
+
+		s.registry.Deregister(agent.ID.String())
+
+		if n, err := s.jobs.FailRunningJobsForAgent(ctx, agent.ID, "agent disconnected"); err != nil {
+			s.logger.Warn("failed to recover orphaned jobs",
+				zap.String("agent_id", agent.ID.String()),
+				zap.Error(err),
+			)
+		} else if n > 0 {
+			s.logger.Info("recovered orphaned jobs",
+				zap.String("agent_id", agent.ID.String()),
+				zap.Int64("count", n),
+			)
+		}
+
+		if s.notif != nil {
+			if err := s.notif.NotifyAgentOffline(ctx, agent.ID, agent.Hostname); err != nil {
+				s.logger.Warn("failed to send agent-offline notification",
+					zap.String("agent_id", agent.ID.String()),
+					zap.Error(err),
+				)
+			}
+		}
+
+		s.pub.Publish("agent:"+agent.ID.String(), websocket.Message{
+			Type:    websocket.MsgAgentStatus,
+			Payload: map[string]any{"status": "offline"},
+		})
+
+		flipped++
+	}
+
+	if flipped > 0 {
+		s.logger.Info("marked stale agents offline", zap.Int("count", flipped))
+	}
+	return flipped
+}

--- a/server/internal/agentwatchdog/service_test.go
+++ b/server/internal/agentwatchdog/service_test.go
@@ -1,0 +1,178 @@
+package agentwatchdog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/arkeep-io/arkeep/server/internal/db"
+	"github.com/arkeep-io/arkeep/server/internal/websocket"
+)
+
+type fakeAgentStore struct {
+	stale       []db.Agent
+	markResults map[uuid.UUID]bool // agent ID -> what MarkOfflineIfStale should return
+	markCalls   []uuid.UUID
+}
+
+func (f *fakeAgentStore) ListStale(_ context.Context, _ time.Time) ([]db.Agent, error) {
+	return f.stale, nil
+}
+
+func (f *fakeAgentStore) MarkOfflineIfStale(_ context.Context, id uuid.UUID, _ time.Time) (bool, error) {
+	f.markCalls = append(f.markCalls, id)
+	return f.markResults[id], nil
+}
+
+type fakeJobStore struct {
+	failCalls []uuid.UUID
+}
+
+func (f *fakeJobStore) FailRunningJobsForAgent(_ context.Context, agentID uuid.UUID, _ string) (int64, error) {
+	f.failCalls = append(f.failCalls, agentID)
+	return 1, nil
+}
+
+type fakeRegistry struct {
+	deregisterCalls []string
+}
+
+func (f *fakeRegistry) Deregister(agentID string) {
+	f.deregisterCalls = append(f.deregisterCalls, agentID)
+}
+
+type fakeNotifier struct {
+	notifyCalls []uuid.UUID
+}
+
+func (f *fakeNotifier) NotifyAgentOffline(_ context.Context, agentID uuid.UUID, _ string) error {
+	f.notifyCalls = append(f.notifyCalls, agentID)
+	return nil
+}
+
+type fakePublisher struct {
+	published []websocket.Message
+	topics    []string
+}
+
+func (f *fakePublisher) Publish(topic string, msg websocket.Message) {
+	f.topics = append(f.topics, topic)
+	f.published = append(f.published, msg)
+}
+
+// TestRunOnce_FlipsStaleAgent verifies that a candidate agent that
+// MarkOfflineIfStale confirms is genuinely stale gets the full offline
+// cleanup: deregister, orphan job recovery, notification, and a live status
+// push — the same sequence StreamJobs runs on a clean disconnect.
+func TestRunOnce_FlipsStaleAgent(t *testing.T) {
+	agentID := uuid.New()
+	agents := &fakeAgentStore{
+		stale:       []db.Agent{{SoftDelete: db.SoftDelete{Base: db.Base{ID: agentID}}, Hostname: "remote-pc"}},
+		markResults: map[uuid.UUID]bool{agentID: true},
+	}
+	jobs := &fakeJobStore{}
+	registry := &fakeRegistry{}
+	notif := &fakeNotifier{}
+	pub := &fakePublisher{}
+
+	svc := NewService(agents, jobs, registry, notif, pub, zap.NewNop())
+	flipped := svc.RunOnce(context.Background())
+
+	if flipped != 1 {
+		t.Errorf("RunOnce() = %d, want 1", flipped)
+	}
+	if len(registry.deregisterCalls) != 1 || registry.deregisterCalls[0] != agentID.String() {
+		t.Errorf("Deregister calls = %v, want [%s]", registry.deregisterCalls, agentID)
+	}
+	if len(jobs.failCalls) != 1 || jobs.failCalls[0] != agentID {
+		t.Errorf("FailRunningJobsForAgent calls = %v, want [%s]", jobs.failCalls, agentID)
+	}
+	if len(notif.notifyCalls) != 1 || notif.notifyCalls[0] != agentID {
+		t.Errorf("NotifyAgentOffline calls = %v, want [%s]", notif.notifyCalls, agentID)
+	}
+	if len(pub.published) != 1 {
+		t.Fatalf("Publish called %d times, want 1", len(pub.published))
+	}
+	if want := "agent:" + agentID.String(); pub.topics[0] != want {
+		t.Errorf("published topic = %q, want %q", pub.topics[0], want)
+	}
+	if pub.published[0].Type != websocket.MsgAgentStatus {
+		t.Errorf("published type = %q, want %q", pub.published[0].Type, websocket.MsgAgentStatus)
+	}
+	if got := pub.published[0].Payload.(map[string]any)["status"]; got != "offline" {
+		t.Errorf("published status = %v, want %q", got, "offline")
+	}
+}
+
+// TestRunOnce_SkipsAgentThatReconnected is the regression case for the race
+// window: MarkOfflineIfStale returning false means the agent heartbeated
+// again between ListStale and the write, so none of the offline cleanup must
+// run — otherwise a live agent would be deregistered and get a spurious
+// offline notification.
+func TestRunOnce_SkipsAgentThatReconnected(t *testing.T) {
+	agentID := uuid.New()
+	agents := &fakeAgentStore{
+		stale:       []db.Agent{{SoftDelete: db.SoftDelete{Base: db.Base{ID: agentID}}, Hostname: "remote-pc"}},
+		markResults: map[uuid.UUID]bool{agentID: false},
+	}
+	jobs := &fakeJobStore{}
+	registry := &fakeRegistry{}
+	notif := &fakeNotifier{}
+	pub := &fakePublisher{}
+
+	svc := NewService(agents, jobs, registry, notif, pub, zap.NewNop())
+	flipped := svc.RunOnce(context.Background())
+
+	if flipped != 0 {
+		t.Errorf("RunOnce() = %d, want 0", flipped)
+	}
+	if len(registry.deregisterCalls) != 0 {
+		t.Errorf("Deregister called %d times, want 0", len(registry.deregisterCalls))
+	}
+	if len(jobs.failCalls) != 0 {
+		t.Errorf("FailRunningJobsForAgent called %d times, want 0", len(jobs.failCalls))
+	}
+	if len(notif.notifyCalls) != 0 {
+		t.Errorf("NotifyAgentOffline called %d times, want 0", len(notif.notifyCalls))
+	}
+	if len(pub.published) != 0 {
+		t.Errorf("Publish called %d times, want 0", len(pub.published))
+	}
+}
+
+// TestRunOnce_NoStaleAgents verifies the common case — nothing to do — is a
+// silent no-op.
+func TestRunOnce_NoStaleAgents(t *testing.T) {
+	agents := &fakeAgentStore{}
+	jobs := &fakeJobStore{}
+	registry := &fakeRegistry{}
+	notif := &fakeNotifier{}
+	pub := &fakePublisher{}
+
+	svc := NewService(agents, jobs, registry, notif, pub, zap.NewNop())
+	if flipped := svc.RunOnce(context.Background()); flipped != 0 {
+		t.Errorf("RunOnce() = %d, want 0", flipped)
+	}
+	if len(pub.published) != 0 {
+		t.Errorf("Publish called %d times, want 0", len(pub.published))
+	}
+}
+
+// TestRunOnce_NilNotifierIsSkipped verifies that a nil notifier (matching how
+// the gRPC server treats a disabled notification.Service) does not panic and
+// simply skips the notification step.
+func TestRunOnce_NilNotifierIsSkipped(t *testing.T) {
+	agentID := uuid.New()
+	agents := &fakeAgentStore{
+		stale:       []db.Agent{{SoftDelete: db.SoftDelete{Base: db.Base{ID: agentID}}, Hostname: "remote-pc"}},
+		markResults: map[uuid.UUID]bool{agentID: true},
+	}
+	svc := NewService(agents, &fakeJobStore{}, &fakeRegistry{}, nil, &fakePublisher{}, zap.NewNop())
+
+	if flipped := svc.RunOnce(context.Background()); flipped != 1 {
+		t.Errorf("RunOnce() = %d, want 1", flipped)
+	}
+}

--- a/server/internal/grpc/server.go
+++ b/server/internal/grpc/server.go
@@ -439,6 +439,13 @@ func (s *Server) StreamJobs(req *proto.StreamJobsRequest, stream proto.AgentServ
 		)
 	}
 
+	// Push the transition to any GUI clients watching this agent, so an
+	// already-open Agents/AgentDetail page updates without a manual refresh.
+	s.hub.Publish("agent:"+req.AgentId, websocket.Message{
+		Type:    websocket.MsgAgentStatus,
+		Payload: map[string]any{"status": "online"},
+	})
+
 	// Register the agent in the in-memory manager so the scheduler can
 	// dispatch jobs to it by calling manager.Dispatch(agentID, job).
 	// Docker availability is read from the capabilities cached during the
@@ -476,6 +483,13 @@ func (s *Server) StreamJobs(req *proto.StreamJobsRequest, stream proto.AgentServ
 			zap.Error(err),
 		)
 	}
+
+	// Push the transition to any GUI clients watching this agent, so an
+	// already-open Agents/AgentDetail page updates without a manual refresh.
+	s.hub.Publish("agent:"+req.AgentId, websocket.Message{
+		Type:    websocket.MsgAgentStatus,
+		Payload: map[string]any{"status": "offline"},
+	})
 
 	// Orphan recovery: any job still "running" when the agent disconnects will
 	// never receive a terminal status report. Mark them as failed so they don't

--- a/server/internal/integration/agent_watchdog_test.go
+++ b/server/internal/integration/agent_watchdog_test.go
@@ -1,0 +1,81 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/arkeep-io/arkeep/server/internal/agentwatchdog"
+	proto "github.com/arkeep-io/arkeep/shared/proto"
+)
+
+// TestStaleAgentWatchdog_MarksOfflineAndRecoversOrphans is the end-to-end
+// regression for issue #234: an agent that stops heartbeating without closing
+// its gRPC stream cleanly (network partition, crash, unplugged cable — no FIN
+// ever reaches the server) must still be detected and marked offline, with its
+// running jobs recovered, exactly as if the stream had closed normally.
+func TestStaleAgentWatchdog_MarksOfflineAndRecoversOrphans(t *testing.T) {
+	ts := newTestServer(t)
+	agent := newFakeAgent(t, ts.addr)
+
+	agentID := agent.register(t)
+	_, cancelStream := agent.openStream(t)
+	defer cancelStream()
+	waitForAgentStatus(t, ts.agentRepo, agentID, "online")
+
+	agentUUID := mustParseUUID(t, agentID)
+	if !ts.agentMgr.IsConnected(agentID) {
+		t.Fatal("agent should be registered in agentManager after StreamJobs opens")
+	}
+
+	// Create a job and drive it to "running", simulating one in flight when the
+	// agent went silent.
+	job := createIntegrationJob(t, ts, agentUUID)
+	agent.reportStatus(t, job.ID.String(), proto.JobStatus_JOB_STATUS_RUNNING)
+	waitForJobStatus(t, ts.jobRepo, job.ID.String(), "running")
+
+	// Simulate the passage of time without heartbeats: rewrite last_seen_at
+	// into the past instead of waiting out the real staleTimeout.
+	stale := time.Now().UTC().Add(-time.Hour)
+	if err := ts.agentRepo.UpdateStatus(context.Background(), agentUUID, "online", stale); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	svc := agentwatchdog.NewService(ts.agentRepo, ts.jobRepo, ts.agentMgr, nil, newTestHub(), zap.NewNop())
+	flipped := svc.RunOnce(context.Background())
+
+	if flipped != 1 {
+		t.Fatalf("RunOnce() = %d, want 1", flipped)
+	}
+
+	waitForAgentStatus(t, ts.agentRepo, agentID, "offline")
+	waitForJobStatus(t, ts.jobRepo, job.ID.String(), "failed")
+
+	if ts.agentMgr.IsConnected(agentID) {
+		t.Error("agent should be deregistered from agentManager after the watchdog marks it offline")
+	}
+}
+
+// TestStaleAgentWatchdog_SkipsRecentlySeenAgent verifies the watchdog does not
+// touch an agent that is genuinely still heartbeating.
+func TestStaleAgentWatchdog_SkipsRecentlySeenAgent(t *testing.T) {
+	ts := newTestServer(t)
+	agent := newFakeAgent(t, ts.addr)
+
+	agentID := agent.register(t)
+	_, cancelStream := agent.openStream(t)
+	defer cancelStream()
+	waitForAgentStatus(t, ts.agentRepo, agentID, "online")
+
+	svc := agentwatchdog.NewService(ts.agentRepo, ts.jobRepo, ts.agentMgr, nil, newTestHub(), zap.NewNop())
+	if flipped := svc.RunOnce(context.Background()); flipped != 0 {
+		t.Errorf("RunOnce() = %d, want 0 for a recently-seen agent", flipped)
+	}
+
+	waitForAgentStatus(t, ts.agentRepo, agentID, "online")
+	if !ts.agentMgr.IsConnected(agentID) {
+		t.Error("agent should remain registered in agentManager")
+	}
+}

--- a/server/internal/integration/helpers_test.go
+++ b/server/internal/integration/helpers_test.go
@@ -118,6 +118,14 @@ func newTestServer(t *testing.T) *testServer {
 	return ts
 }
 
+// newTestHub returns an idle websocket.Hub. Publish is safe to call on it
+// without starting Run — there are simply no subscribers to deliver to, which
+// is all these tests need since they assert on repository/agentManager state,
+// not on delivered WebSocket frames.
+func newTestHub() *websocket.Hub {
+	return websocket.NewHub()
+}
+
 // createIntegrationJob inserts a job record with a real policy (and the given
 // agentID) to satisfy FK constraints. Returns the created job.
 func createIntegrationJob(t *testing.T, ts *testServer, agentUUID uuid.UUID) *db.Job {

--- a/server/internal/repositories/agent.go
+++ b/server/internal/repositories/agent.go
@@ -75,6 +75,39 @@ func (r *gormAgentRepository) UpdateStatus(ctx context.Context, id uuid.UUID, st
 	return nil
 }
 
+// ListStale returns online agents whose last_seen_at is older than cutoff —
+// candidates for the stale-agent watchdog to mark offline. Soft-deleted
+// agents are excluded by GORM's default scope.
+func (r *gormAgentRepository) ListStale(ctx context.Context, cutoff time.Time) ([]db.Agent, error) {
+	var agents []db.Agent
+	if err := r.db.WithContext(ctx).
+		Where("status = ? AND last_seen_at < ?", "online", cutoff).
+		Find(&agents).Error; err != nil {
+		return nil, fmt.Errorf("agents: list stale: %w", err)
+	}
+	return agents, nil
+}
+
+// MarkOfflineIfStale atomically flips an agent to offline, but only if it is
+// still online and still stale at write time. The condition is re-checked in
+// the UPDATE's WHERE clause, closing the race window against an agent that
+// reconnects (refreshing last_seen_at) between a ListStale read and this
+// write. Returns whether the row was actually flipped, so the caller only
+// runs offline cleanup (orphan jobs, notification) on a genuine transition.
+//
+// last_seen_at is deliberately left untouched: it records the last real
+// contact from the agent, not the moment the watchdog declared it dead.
+func (r *gormAgentRepository) MarkOfflineIfStale(ctx context.Context, id uuid.UUID, cutoff time.Time) (bool, error) {
+	result := r.db.WithContext(ctx).
+		Model(&db.Agent{}).
+		Where("id = ? AND status = ? AND last_seen_at < ?", id, "online", cutoff).
+		Update("status", "offline")
+	if result.Error != nil {
+		return false, fmt.Errorf("agents: mark offline if stale: %w", result.Error)
+	}
+	return result.RowsAffected > 0, nil
+}
+
 // Delete soft-deletes an agent by setting deleted_at. The record remains in
 // the database and can be restored. Use Unscoped().Delete() for hard delete.
 func (r *gormAgentRepository) Delete(ctx context.Context, id uuid.UUID) error {

--- a/server/internal/repositories/agent_test.go
+++ b/server/internal/repositories/agent_test.go
@@ -1,0 +1,115 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/arkeep-io/arkeep/server/internal/db"
+)
+
+// createTestAgent inserts an agent with the given status and last_seen_at,
+// returning its ID.
+func createTestAgent(t *testing.T, repo AgentRepository, status string, lastSeenAt time.Time) uuid.UUID {
+	t.Helper()
+	agent := &db.Agent{
+		Name:       "test-agent",
+		Hostname:   "host",
+		Status:     status,
+		LastSeenAt: &lastSeenAt,
+	}
+	if err := repo.Create(context.Background(), agent); err != nil {
+		t.Fatalf("Create agent: %v", err)
+	}
+	return agent.ID
+}
+
+// TestMarkOfflineIfStale_FlipsAStaleOnlineAgent verifies the core transition:
+// an online agent whose last_seen_at predates the cutoff is flipped offline.
+func TestMarkOfflineIfStale_FlipsAStaleOnlineAgent(t *testing.T) {
+	repo := NewAgentRepository(newTestDB(t))
+	cutoff := time.Now().UTC()
+	id := createTestAgent(t, repo, "online", cutoff.Add(-time.Hour))
+
+	ok, err := repo.MarkOfflineIfStale(context.Background(), id, cutoff)
+	if err != nil {
+		t.Fatalf("MarkOfflineIfStale: %v", err)
+	}
+	if !ok {
+		t.Fatal("MarkOfflineIfStale() = false, want true for a stale online agent")
+	}
+
+	agent, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if agent.Status != "offline" {
+		t.Errorf("Status = %q, want %q", agent.Status, "offline")
+	}
+}
+
+// TestMarkOfflineIfStale_KeepsARecentlySeenAgent is the regression case for the
+// race with a live heartbeat: an agent whose last_seen_at is AFTER the cutoff
+// (it heartbeated again between the caller's ListStale read and this write)
+// must not be flipped, even if it was passed in as a candidate.
+func TestMarkOfflineIfStale_KeepsARecentlySeenAgent(t *testing.T) {
+	repo := NewAgentRepository(newTestDB(t))
+	cutoff := time.Now().UTC()
+	id := createTestAgent(t, repo, "online", cutoff.Add(time.Minute))
+
+	ok, err := repo.MarkOfflineIfStale(context.Background(), id, cutoff)
+	if err != nil {
+		t.Fatalf("MarkOfflineIfStale: %v", err)
+	}
+	if ok {
+		t.Fatal("MarkOfflineIfStale() = true, want false — the agent heartbeated after the cutoff")
+	}
+
+	agent, err := repo.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if agent.Status != "online" {
+		t.Errorf("Status = %q, want %q — a recently-seen agent must not be flipped", agent.Status, "online")
+	}
+}
+
+// TestMarkOfflineIfStale_AlreadyOfflineIsANoop verifies idempotency: calling
+// it again on an already-offline agent reports no transition.
+func TestMarkOfflineIfStale_AlreadyOfflineIsANoop(t *testing.T) {
+	repo := NewAgentRepository(newTestDB(t))
+	cutoff := time.Now().UTC()
+	id := createTestAgent(t, repo, "offline", cutoff.Add(-time.Hour))
+
+	ok, err := repo.MarkOfflineIfStale(context.Background(), id, cutoff)
+	if err != nil {
+		t.Fatalf("MarkOfflineIfStale: %v", err)
+	}
+	if ok {
+		t.Error("MarkOfflineIfStale() = true, want false — the agent was already offline")
+	}
+}
+
+// TestListStale_ReturnsOnlyOnlineAgentsPastCutoff verifies the candidate query:
+// only online agents whose last_seen_at predates the cutoff come back.
+func TestListStale_ReturnsOnlyOnlineAgentsPastCutoff(t *testing.T) {
+	repo := NewAgentRepository(newTestDB(t))
+	cutoff := time.Now().UTC()
+
+	staleID := createTestAgent(t, repo, "online", cutoff.Add(-time.Hour))
+	createTestAgent(t, repo, "online", cutoff.Add(time.Minute)) // recently seen
+	createTestAgent(t, repo, "offline", cutoff.Add(-time.Hour)) // already offline
+
+	stale, err := repo.ListStale(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("ListStale: %v", err)
+	}
+	if len(stale) != 1 {
+		t.Fatalf("ListStale() returned %d agents, want 1: %+v", len(stale), stale)
+	}
+	if stale[0].ID != staleID {
+		t.Errorf("ListStale() returned agent %s, want %s", stale[0].ID, staleID)
+	}
+}

--- a/server/internal/repositories/repositories.go
+++ b/server/internal/repositories/repositories.go
@@ -104,6 +104,8 @@ type AgentRepository interface {
 	GetByHostname(ctx context.Context, hostname string) (*db.Agent, error)
 	Update(ctx context.Context, agent *db.Agent) error
 	UpdateStatus(ctx context.Context, id uuid.UUID, status string, lastSeenAt time.Time) error
+	ListStale(ctx context.Context, cutoff time.Time) ([]db.Agent, error)
+	MarkOfflineIfStale(ctx context.Context, id uuid.UUID, cutoff time.Time) (bool, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	List(ctx context.Context, opts ListOptions) ([]db.Agent, int64, error)
 	ListFiltered(ctx context.Context, filter AgentFilter, opts ListOptions) ([]db.Agent, int64, error)


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues

Closes #234 
