### PR TITLE
fix: recover from stale restic locks and shut down subprocesses

### DIFF
--- a/agent/cmd/agent/main.go
+++ b/agent/cmd/agent/main.go
@@ -130,7 +130,7 @@ func run(ctx context.Context, cfg *config) error {
 	// Idempotent: skips extraction if the file already exists with the
 	// correct size. Must run before NewWrapper.
 	extractor := restic.NewExtractor(cfg.stateDir)
-	wrapper, err := restic.NewWrapper(extractor)
+	wrapper, err := restic.NewWrapper(extractor, logger)
 	if err != nil {
 		return fmt.Errorf("failed to prepare restic/rclone binaries: %w", err)
 	}

--- a/agent/internal/restic/wrapper.go
+++ b/agent/internal/restic/wrapper.go
@@ -18,12 +18,23 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
+
+	"go.uber.org/zap"
 )
+
+// cancelGracePeriod is how long a restic subprocess is given to exit after
+// receiving SIGINT (see buildCmd) before Go escalates to SIGKILL. Kept well
+// under systemd's default TimeoutStopSec (30s) so a clean shutdown always has
+// a chance to complete before the service manager forces a kill.
+const cancelGracePeriod = 15 * time.Second
 
 // DestinationType identifies the storage backend for a destination.
 // It maps directly to the db.Destination.Type field on the server.
@@ -159,11 +170,12 @@ type ProgressFunc func(event ProgressEvent) error
 type Wrapper struct {
 	resticBin string // absolute path to the extracted restic binary
 	rcloneBin string // absolute path to the extracted rclone binary
+	logger    *zap.Logger
 }
 
 // NewWrapper extracts the embedded binaries (if needed) and returns a ready
 // Wrapper. This should be called once at agent startup.
-func NewWrapper(extractor *Extractor) (*Wrapper, error) {
+func NewWrapper(extractor *Extractor, logger *zap.Logger) (*Wrapper, error) {
 	resticBin, err := extractor.ResticPath()
 	if err != nil {
 		return nil, fmt.Errorf("restic: failed to prepare restic binary: %w", err)
@@ -177,6 +189,7 @@ func NewWrapper(extractor *Extractor) (*Wrapper, error) {
 	return &Wrapper{
 		resticBin: resticBin,
 		rcloneBin: rcloneBin,
+		logger:    logger.Named("restic"),
 	}, nil
 }
 
@@ -497,38 +510,40 @@ func parseResticStats(r io.Reader) (StatsResult, bool, error) {
 // with a bind-mounted host filesystem); on native binaries hostRoot is "" and
 // all errors are propagated unchanged.
 func (w *Wrapper) runRestoreJSON(ctx context.Context, dest Destination, args []string, hostRoot string) error {
-	cmd := w.buildCmd(ctx, dest, args)
+	return w.withLockRetry(ctx, dest, func() error {
+		cmd := w.buildCmd(ctx, dest, args)
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("restic: failed to open stdout pipe: %w", err)
-	}
-	var stderrBuf strings.Builder
-	cmd.Stderr = &stderrBuf
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("restic: failed to start: %w", err)
-	}
-
-	// Drain stdout to prevent the subprocess from blocking when its pipe buffer
-	// fills up. We ignore the JSON content for now — restore progress is not
-	// currently streamed to the UI.
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		// discard
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("restic: failed to read stdout: %w", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		stderr := strings.TrimSpace(stderrBuf.String())
-		if hostRoot != "" && isOnlyHostRootLchownErrors(stderr, hostRoot) {
-			return nil
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("restic: failed to open stdout pipe: %w", err)
 		}
-		return fmt.Errorf("restic: command failed: %w\n%s", err, stderr)
-	}
-	return nil
+		var stderrBuf strings.Builder
+		cmd.Stderr = &stderrBuf
+
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("restic: failed to start: %w", err)
+		}
+
+		// Drain stdout to prevent the subprocess from blocking when its pipe buffer
+		// fills up. We ignore the JSON content for now — restore progress is not
+		// currently streamed to the UI.
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			// discard
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("restic: failed to read stdout: %w", err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			stderr := strings.TrimSpace(stderrBuf.String())
+			if hostRoot != "" && isOnlyHostRootLchownErrors(stderr, hostRoot) {
+				return nil
+			}
+			return fmt.Errorf("restic: command failed: %w\n%s", err, stderr)
+		}
+		return nil
+	})
 }
 
 // isOnlyHostRootLchownErrors returns true when every error restic encountered
@@ -600,29 +615,94 @@ func isOnlyHostRootLchownErrors(stderr, hostRoot string) bool {
 	return foundLchownError
 }
 
-// run executes a restic command and waits for it to finish.
-// stderr is captured and included in the error if the command fails.
-func (w *Wrapper) run(ctx context.Context, dest Destination, args []string) error {
-	cmd := w.buildCmd(ctx, dest, args)
+// lockConflictExitCode is restic's dedicated, stable exit status for "unable
+// to create lock in backend: repository is already locked" — distinct from
+// its other error codes, so detecting it doesn't require matching the
+// human-readable (and version-dependent) error string.
+const lockConflictExitCode = 11
+
+// isLockConflict reports whether err is restic exiting because it could not
+// acquire a repository lock. err may be wrapped (e.g. via fmt.Errorf's %w),
+// so this unwraps down to the underlying *exec.ExitError rather than doing a
+// direct type assertion.
+func isLockConflict(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return exitErr.ExitCode() == lockConflictExitCode
+}
+
+// unlock runs `restic unlock` (without --remove-all) against dest's
+// repository. This only removes locks restic itself judges stale — created
+// more than 30 minutes ago, or created by a PID no longer running on this
+// host — so it never touches a lock genuinely held by a live operation, even
+// one running on a different host. Safe to call speculatively.
+func (w *Wrapper) unlock(ctx context.Context, dest Destination) error {
+	cmd := w.buildCmd(ctx, dest, []string{"unlock"})
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("restic: command failed: %w\n%s", err, strings.TrimSpace(string(out)))
+		return fmt.Errorf("restic: unlock failed: %w\n%s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 
+// withLockRetry runs fn once. If fn fails because the repository is already
+// locked, it attempts to clear a stale lock via unlock and, if that succeeds,
+// runs fn again exactly once.
+//
+// This is what lets a backup recover from an exclusive lock orphaned by a
+// forget/prune that was killed mid-run (see buildCmd's graceful-cancellation
+// handling for the other half of this fix) instead of failing identically on
+// every future run against the same destination. A second failure — including
+// a fresh lock conflict, meaning some other operation is genuinely still
+// running — is returned as-is; there is no unbounded retry loop.
+func (w *Wrapper) withLockRetry(ctx context.Context, dest Destination, fn func() error) error {
+	err := fn()
+	if !isLockConflict(err) {
+		return err
+	}
+	if unlockErr := w.unlock(ctx, dest); unlockErr != nil {
+		// Could not confirm/clear the lock (e.g. it genuinely isn't stale) —
+		// surface the original conflict rather than the unlock attempt's error.
+		w.logger.Debug("restic: repository locked, unlock attempt did not clear it",
+			zap.Error(unlockErr))
+		return err
+	}
+	w.logger.Warn("restic: recovered from a stale repository lock, retrying")
+	return fn()
+}
+
+// run executes a restic command and waits for it to finish.
+// stderr is captured and included in the error if the command fails.
+func (w *Wrapper) run(ctx context.Context, dest Destination, args []string) error {
+	return w.withLockRetry(ctx, dest, func() error {
+		cmd := w.buildCmd(ctx, dest, args)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("restic: command failed: %w\n%s", err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	})
+}
+
 // output executes a restic command and returns its stdout as raw bytes.
 func (w *Wrapper) output(ctx context.Context, dest Destination, args []string) ([]byte, error) {
-	cmd := w.buildCmd(ctx, dest, args)
-	out, err := cmd.Output()
-	if err != nil {
-		stderr := ""
-		if ee, ok := err.(*exec.ExitError); ok {
-			stderr = strings.TrimSpace(string(ee.Stderr))
+	var result []byte
+	err := w.withLockRetry(ctx, dest, func() error {
+		cmd := w.buildCmd(ctx, dest, args)
+		out, err := cmd.Output()
+		if err != nil {
+			stderr := ""
+			if ee, ok := err.(*exec.ExitError); ok {
+				stderr = strings.TrimSpace(string(ee.Stderr))
+			}
+			return fmt.Errorf("restic: command failed: %w\n%s", err, stderr)
 		}
-		return nil, fmt.Errorf("restic: command failed: %w\n%s", err, stderr)
-	}
-	return out, nil
+		result = out
+		return nil
+	})
+	return result, err
 }
 
 // runWithProgress executes a restic command, reading stdout line by line and
@@ -634,55 +714,57 @@ func (w *Wrapper) output(ctx context.Context, dest Destination, args []string) (
 // has a "message_type" field that identifies the event kind. Non-JSON lines
 // (e.g. deprecation warnings) are logged at debug level and skipped.
 func (w *Wrapper) runWithProgress(ctx context.Context, dest Destination, args []string, onProgress ProgressFunc) error {
-	cmd := w.buildCmd(ctx, dest, args)
+	return w.withLockRetry(ctx, dest, func() error {
+		cmd := w.buildCmd(ctx, dest, args)
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("restic: failed to open stdout pipe: %w", err)
-	}
-
-	// Collect stderr separately so it can be included in error messages.
-	var stderrBuf strings.Builder
-	cmd.Stderr = &stderrBuf
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("restic: failed to start: %w", err)
-	}
-
-	// Read stdout line by line, parsing each as a JSON progress event.
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("restic: failed to open stdout pipe: %w", err)
 		}
 
-		var event ProgressEvent
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			// Non-JSON line (e.g. a warning from an older restic version) —
-			// skip silently. The raw line is not forwarded to avoid noise.
-			continue
-		}
-		event.Raw = line
+		// Collect stderr separately so it can be included in error messages.
+		var stderrBuf strings.Builder
+		cmd.Stderr = &stderrBuf
 
-		if onProgress != nil {
-			if err := onProgress(event); err != nil {
-				// Caller signalled cancellation — kill the process.
-				// Ignore the kill error: the process may have already exited.
-				_ = cmd.Process.Kill()
-				return fmt.Errorf("restic: progress callback cancelled: %w", err)
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("restic: failed to start: %w", err)
+		}
+
+		// Read stdout line by line, parsing each as a JSON progress event.
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
+
+			var event ProgressEvent
+			if err := json.Unmarshal([]byte(line), &event); err != nil {
+				// Non-JSON line (e.g. a warning from an older restic version) —
+				// skip silently. The raw line is not forwarded to avoid noise.
+				continue
+			}
+			event.Raw = line
+
+			if onProgress != nil {
+				if err := onProgress(event); err != nil {
+					// Caller signalled cancellation — kill the process.
+					// Ignore the kill error: the process may have already exited.
+					_ = cmd.Process.Kill()
+					return fmt.Errorf("restic: progress callback cancelled: %w", err)
+				}
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("restic: failed to read stdout: %w", err)
-	}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("restic: failed to read stdout: %w", err)
+		}
 
-	if err := cmd.Wait(); err != nil {
-		stderr := strings.TrimSpace(stderrBuf.String())
-		return fmt.Errorf("restic: command failed: %w\n%s", err, stderr)
-	}
-	return nil
+		if err := cmd.Wait(); err != nil {
+			stderr := strings.TrimSpace(stderrBuf.String())
+			return fmt.Errorf("restic: command failed: %w\n%s", err, stderr)
+		}
+		return nil
+	})
 }
 
 // buildCmd constructs the exec.Cmd for a restic invocation.
@@ -702,6 +784,16 @@ func (w *Wrapper) buildCmd(ctx context.Context, dest Destination, args []string)
 	}
 
 	cmd := exec.CommandContext(ctx, w.resticBin, args...)
+
+	// By default, exec.CommandContext kills the process with SIGKILL the
+	// instant ctx is cancelled — restic never gets a chance to run its own
+	// shutdown handler, which releases its repository lock. Sending SIGINT
+	// instead lets restic clean up (it explicitly handles this, same as a
+	// user pressing Ctrl-C), avoiding an orphaned exclusive lock that would
+	// otherwise block every future backup to this repository. WaitDelay is a
+	// safety net: if restic doesn't exit within it, Go falls back to SIGKILL.
+	cmd.Cancel = func() error { return cmd.Process.Signal(os.Interrupt) }
+	cmd.WaitDelay = cancelGracePeriod
 
 	// Build environment: start from the current process env so that PATH,
 	// HOME, and system variables are inherited, then overlay restic-specific

--- a/agent/internal/restic/wrapper_test.go
+++ b/agent/internal/restic/wrapper_test.go
@@ -2,9 +2,18 @@ package restic
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
+
+	"go.uber.org/zap"
 )
 
 // TestParseResticStats verifies the repository size is extracted from
@@ -284,5 +293,163 @@ func TestBuildForgetArgs(t *testing.T) {
 				t.Errorf("buildForgetArgs() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestBuildCmd_GracefulCancelSendsSIGINT verifies that cancelling the context
+// passed to buildCmd sends SIGINT to the child process instead of the Go
+// default (an immediate SIGKILL). This is what gives restic a chance to run
+// its own shutdown handler and release its repository lock — without it, any
+// cancellation (job cancel, agent shutdown, systemd restart) that lands
+// mid-operation orphans an exclusive lock that blocks every future run.
+func TestBuildCmd_GracefulCancelSendsSIGINT(t *testing.T) {
+	// /bin/sleep installs no signal handler of its own, so its termination
+	// signal directly reflects what buildCmd's cmd.Cancel actually sent —
+	// no shell/trap semantics in the way (POSIX shells only run pending traps
+	// once their current foreground child exits, which would make a
+	// shell-script stand-in useless for testing prompt signal delivery).
+	w := &Wrapper{resticBin: "/bin/sleep", rcloneBin: "/fake/rclone", logger: zap.NewNop()}
+	dest := Destination{Type: DestLocal, RepoURL: "/tmp", Password: "pw"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := w.buildCmd(ctx, dest, []string{"5"})
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start /bin/sleep: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	waitErr := cmd.Wait()
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		t.Fatalf("Wait() error = %v, want *exec.ExitError", waitErr)
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatalf("could not read a Unix wait status from %v", exitErr)
+	}
+	if !ws.Signaled() || ws.Signal() != syscall.SIGINT {
+		t.Errorf("process terminated by signal %v (signaled=%v), want SIGINT — "+
+			"the default (Go stdlib) behavior of an immediate SIGKILL would never "+
+			"give restic a chance to release its repository lock", ws.Signal(), ws.Signaled())
+	}
+}
+
+// writeFakeResticScript creates a shell script standing in for the restic
+// binary. It handles two commands: "unlock", which always succeeds and
+// records that it ran, and any other command ("the real command"), which
+// fails with restic's lock-conflict exit code (11) for the first failTimes
+// invocations and succeeds afterwards. Invocation counts are tracked via
+// files so the test can assert exactly how many times each command ran.
+func writeFakeResticScript(t *testing.T, dir string, failTimes int) (script, counterFile, unlockMarker string) {
+	t.Helper()
+	script = filepath.Join(dir, "fake-restic.sh")
+	counterFile = filepath.Join(dir, "count")
+	unlockMarker = filepath.Join(dir, "unlocked")
+
+	body := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "unlock" ]; then
+  echo ran >> %q
+  exit 0
+fi
+count=0
+if [ -f %q ]; then
+  count=$(cat %q)
+fi
+count=$((count+1))
+echo "$count" > %q
+if [ "$count" -le %d ]; then
+  echo "unable to create lock in backend: repository is already locked exclusively" >&2
+  exit 11
+fi
+exit 0
+`, unlockMarker, counterFile, counterFile, counterFile, failTimes)
+
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script, counterFile, unlockMarker
+}
+
+func readCounter(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(data)), "%d", &n); err != nil {
+		t.Fatalf("failed to parse counter file %q = %q: %v", path, data, err)
+	}
+	return n
+}
+
+// TestRun_RetriesOnceAfterUnlockOnLockConflict is the end-to-end regression
+// for issue #252: a command that fails once with restic's lock-conflict exit
+// code must trigger `restic unlock` and a single retry, succeeding overall —
+// instead of failing identically forever the way Arkeep did before this fix.
+func TestRun_RetriesOnceAfterUnlockOnLockConflict(t *testing.T) {
+	dir := t.TempDir()
+	script, counterFile, unlockMarker := writeFakeResticScript(t, dir, 1)
+	w := &Wrapper{resticBin: script, rcloneBin: "/fake/rclone", logger: zap.NewNop()}
+	dest := Destination{Type: DestLocal, RepoURL: dir, Password: "pw"}
+
+	if err := w.run(context.Background(), dest, []string{"forget"}); err != nil {
+		t.Fatalf("run() = %v, want nil (should recover after unlock)", err)
+	}
+
+	if got := readCounter(t, counterFile); got != 2 {
+		t.Errorf("real command invoked %d times, want 2 (one failure + one retry)", got)
+	}
+	if _, err := os.Stat(unlockMarker); err != nil {
+		t.Error("restic unlock was not invoked")
+	}
+}
+
+// TestRun_DoesNotRetryOnOtherErrors verifies that only the specific
+// lock-conflict exit code (11) triggers the unlock-and-retry path — any other
+// failure is returned immediately, with no unlock attempt.
+func TestRun_DoesNotRetryOnOtherErrors(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-restic.sh")
+	unlockMarker := filepath.Join(dir, "unlocked")
+	body := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"unlock\" ]; then echo ran >> %q; exit 0; fi\nexit 1\n", unlockMarker)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &Wrapper{resticBin: script, rcloneBin: "/fake/rclone", logger: zap.NewNop()}
+	dest := Destination{Type: DestLocal, RepoURL: dir, Password: "pw"}
+
+	if err := w.run(context.Background(), dest, []string{"forget"}); err == nil {
+		t.Fatal("run() = nil, want an error for a non-lock-conflict failure")
+	}
+	if _, err := os.Stat(unlockMarker); err == nil {
+		t.Error("restic unlock should not be invoked for a non-lock-conflict failure")
+	}
+}
+
+// TestRun_FailsIfSecondAttemptAlsoLocked verifies there is no unbounded retry
+// loop: if the retry ALSO hits a lock conflict (e.g. another operation is
+// genuinely still running), the error is propagated after exactly one retry.
+func TestRun_FailsIfSecondAttemptAlsoLocked(t *testing.T) {
+	dir := t.TempDir()
+	script, counterFile, unlockMarker := writeFakeResticScript(t, dir, 2)
+	w := &Wrapper{resticBin: script, rcloneBin: "/fake/rclone", logger: zap.NewNop()}
+	dest := Destination{Type: DestLocal, RepoURL: dir, Password: "pw"}
+
+	if err := w.run(context.Background(), dest, []string{"forget"}); err == nil {
+		t.Fatal("run() = nil, want an error when the retry also hits a lock conflict")
+	}
+
+	if got := readCounter(t, counterFile); got != 2 {
+		t.Errorf("real command invoked %d times, want 2 (one failure + exactly one retry, no more)", got)
+	}
+	if _, err := os.Stat(unlockMarker); err != nil {
+		t.Error("restic unlock should have been attempted once")
 	}
 }


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Tests
- [ ] Chore / deps

## Checklist

- [x] `task test` passes locally
- [x] `task lint` passes locally
- [x] Tests added or updated if needed
- [x] Documentation updated if needed
- [x] Linked to a related issue (if applicable)

## Related Issues

Closes #252 
